### PR TITLE
Convert enumeration values into a string when printing

### DIFF
--- a/xmlschema/components/facets.py
+++ b/xmlschema/components/facets.py
@@ -290,7 +290,7 @@ class XsdEnumerationFacet(MutableSequence, XsdFacet):
 
     def __repr__(self):
         if len(self.enumeration) > 5:
-            enum_repr = '[%s, ...]' % ', '.join(self.enumeration[:5])
+            enum_repr = '[%s, ...]' % ', '.join(map(repr, self.enumeration[:5]))
         else:
             enum_repr = repr(self.enumeration)
         return u"<%s %r at %#x>" % (self.__class__.__name__, enum_repr, id(self))


### PR DESCRIPTION
The following is a failing testcase for `XsdEnumerationFacet`'s `repr` method

```py
import xmlschema

schema = xmlschema.XMLSchema("""
<?xml version="1.0" encoding="UTF-8"?>
<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
    elementFormDefault="qualified"
    attributeFormDefault="unqualified">

    <xs:element name="foo" type="Foo" />

    <xs:simpleType name="Foo">
        <xs:restriction base="xs:integer">
            <xs:enumeration value="0"/>
            <xs:enumeration value="1"/>
            <xs:enumeration value="2"/>
            <xs:enumeration value="3"/>
            <xs:enumeration value="4"/>
            <xs:enumeration value="5"/>
        </xs:restriction>
    </xs:simpleType>

</xs:schema>
""".strip())
Foo = schema.types['Foo']
print(repr(Foo.facets))
```


```
Traceback (most recent call last):
  File "fail.py", line 25, in <module>
    print(repr(Foo.facets))
  File "/home/andrew/Repos/xmlschema/xmlschema/components/facets.py", line 293, in __repr__
    enum_repr = '[%s, ...]' % ', '.join(self.enumeration[:5])
TypeError: sequence item 0: expected str instance, int found
```
