### PR TITLE
XsdConstraint: fix Counter update

### DIFF
--- a/xmlschema/validators/constraints.py
+++ b/xmlschema/validators/constraints.py
@@ -166,7 +166,7 @@ class XsdConstraint(XsdAnnotated):
             if isinstance(v, XMLSchemaValidationError):
                 yield v
             else:
-                values.update(v)
+                values[v] += 1
 
         for value, count in values.items():
             if count > 1:


### PR DESCRIPTION
The Counter.update method expects a sequence of elements, but
the 'v' variable refers to a tuple which represents a single
element rather than a sequence of elements.