### PR TITLE
XsdConstraint: do not require key field to have a value

### DIFF
--- a/xmlschema/validators/constraints.py
+++ b/xmlschema/validators/constraints.py
@@ -98,10 +98,7 @@ class XsdConstraint(XsdAnnotated):
         for k, field in enumerate(self.fields):
             result = list(field.iter_select(context))
             if not result:
-                if isinstance(self, XsdKey):
-                    raise XMLSchemaValueError("%r key field must have a value!" % field)
-                else:
-                    fields.append(None)
+                fields.append(None)
             elif len(result) == 1:
                 if decoders is None or decoders[k] is None:
                     fields.append(result[0])


### PR DESCRIPTION
The lxml.etree.XMLSchema allows missing values for key fields, it
is only required that the combination of all the field values be
unique.