### PR TITLE
Fix escape sequence warning using raw string

### DIFF
--- a/xmlschema/resources.py
+++ b/xmlschema/resources.py
@@ -523,12 +523,12 @@ class XMLResource(object):
             elif not any(uri == ns for ns in nsmap.values()):
                 if not prefix:
                     try:
-                        prefix = re.search('(\w+)$', uri.strip()).group()
+                        prefix = re.search(r'(\w+)$', uri.strip()).group()
                     except AttributeError:
                         return
 
                 while prefix in nsmap:
-                    match = re.search('(\d+)$', prefix)
+                    match = re.search(r'(\d+)$', prefix)
                     if match:
                         index = int(match.group()) + 1
                         prefix = prefix[:match.span()[0]] + str(index)


### PR DESCRIPTION
Using raw literals prevents these warnings. Fixes #95 

```shell
./python.exe
Python 3.8.0a0 (heads/bpo35560-dirty:583759248c, Dec 23 2018, 01:51:51)
[Clang 7.0.2 (clang-700.1.81)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import re
>>> re.search('(\w+)', 'ab')
<stdin>:1: SyntaxWarning: invalid escape sequence \w
<re.Match object; span=(0, 2), match='ab'>
>>> re.search(r'(\w+)', 'ab')
<re.Match object; span=(0, 2), match='ab'>
```