### PR TITLE
Fixed issue: backslashes were not properly escaped when creating pyth…

### DIFF
--- a/xmlschema/codepoints.py
+++ b/xmlschema/codepoints.py
@@ -21,7 +21,7 @@ from collections import defaultdict
 from .compat import PY3, unicode_chr, string_base_type, Iterable, MutableSet
 from .exceptions import XMLSchemaValueError, XMLSchemaTypeError, XMLSchemaRegexError
 
-CHARACTER_GROUP_ESCAPED = {ord(c) for c in r'-|.^?*+{}()[]'}
+CHARACTER_GROUP_ESCAPED = {ord(c) for c in r'-|.^?*+{}()[]\\'}
 """Code Points of escaped chars in a character group."""
 
 UCS4_MAXUNICODE = 1114111

--- a/xmlschema/regex.py
+++ b/xmlschema/regex.py
@@ -69,6 +69,7 @@ CHARACTER_ESCAPES = {
     '\\)': ')',
     '\\[': '[',
     '\\]': ']',
+    '\\\\': '\\',
 
     # Multi-character escapes
     '\\s': S_SHORTCUT_SET,


### PR DESCRIPTION
…on regular expressions from xml

Example to reproduce the problem:

```
import xmlschema


schema = xmlschema.XMLSchema("test.xsd")

schema.to_dict("""<?xml version="1.0" encoding="UTF-8"?>
                  <test xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">TEST[]</test>""")

```

test.xsd:
```
<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="test">
	  <xs:simpleType>
		 <xs:restriction base="xs:string">
			<xs:pattern value='[A-Z\\\[\]]{0,2000}'/>
		 </xs:restriction>
	  </xs:simpleType>
   </xs:element>
</xs:schema>
```