### PR TITLE
Regexp: Fix implementation of multi-character escapes.

### DIFF
--- a/xmlschema/regex.py
+++ b/xmlschema/regex.py
@@ -45,15 +45,25 @@ C_SHORTCUT_REPLACE = (
     "\u200D\u203F\u2040\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD"
 )
 
-S_SHORTCUT_SET = UnicodeSubset(' \n\t\r')
-D_SHORTCUT_SET = UnicodeSubset('0-9')
-I_SHORTCUT_SET = UnicodeSubset(I_SHORTCUT_REPLACE)
-C_SHORTCUT_SET = UnicodeSubset(C_SHORTCUT_REPLACE)
+s_SHORTCUT_SET = UnicodeSubset(' \n\t\r')
+S_SHORTCUT_SET = UnicodeSubset(s_SHORTCUT_SET.complement())
+
+d_SHORTCUT_SET = UnicodeSubset()
+d_SHORTCUT_SET._code_points = UNICODE_CATEGORIES['Nd'].code_points
+D_SHORTCUT_SET = UnicodeSubset(d_SHORTCUT_SET.complement())
+
+i_SHORTCUT_SET = UnicodeSubset(I_SHORTCUT_REPLACE)
+I_SHORTCUT_SET = UnicodeSubset(i_SHORTCUT_SET.complement())
+
+c_SHORTCUT_SET = UnicodeSubset(C_SHORTCUT_REPLACE)
+C_SHORTCUT_SET = UnicodeSubset(c_SHORTCUT_SET.complement())
+
 W_SHORTCUT_SET = UnicodeSubset()
 W_SHORTCUT_SET._code_points = sorted(
     UNICODE_CATEGORIES['P'].code_points + UNICODE_CATEGORIES['Z'].code_points +
     UNICODE_CATEGORIES['C'].code_points, key=lambda x: x if isinstance(x, int) else x[0]
 )
+w_SHORTCUT_SET = UnicodeSubset(W_SHORTCUT_SET.complement())
 
 # Single and Multi character escapes
 CHARACTER_ESCAPES = {
@@ -77,15 +87,15 @@ CHARACTER_ESCAPES = {
     '\\\\': '\\',
 
     # Multi-character escapes
-    '\\s': S_SHORTCUT_SET,
+    '\\s': s_SHORTCUT_SET,
     '\\S': S_SHORTCUT_SET,
-    '\\d': D_SHORTCUT_SET,
+    '\\d': d_SHORTCUT_SET,
     '\\D': D_SHORTCUT_SET,
-    '\\i': I_SHORTCUT_SET,
+    '\\i': i_SHORTCUT_SET,
     '\\I': I_SHORTCUT_SET,
-    '\\c': C_SHORTCUT_SET,
+    '\\c': c_SHORTCUT_SET,
     '\\C': C_SHORTCUT_SET,
-    '\\w': W_SHORTCUT_SET,
+    '\\w': w_SHORTCUT_SET,
     '\\W': W_SHORTCUT_SET,
 }
 

--- a/xmlschema/regex.py
+++ b/xmlschema/regex.py
@@ -45,25 +45,17 @@ C_SHORTCUT_REPLACE = (
     "\u200D\u203F\u2040\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD"
 )
 
-s_SHORTCUT_SET = UnicodeSubset(' \n\t\r')
-S_SHORTCUT_SET = UnicodeSubset(s_SHORTCUT_SET.complement())
-
-d_SHORTCUT_SET = UnicodeSubset()
-d_SHORTCUT_SET._code_points = UNICODE_CATEGORIES['Nd'].code_points
-D_SHORTCUT_SET = UnicodeSubset(d_SHORTCUT_SET.complement())
-
-i_SHORTCUT_SET = UnicodeSubset(I_SHORTCUT_REPLACE)
-I_SHORTCUT_SET = UnicodeSubset(i_SHORTCUT_SET.complement())
-
-c_SHORTCUT_SET = UnicodeSubset(C_SHORTCUT_REPLACE)
-C_SHORTCUT_SET = UnicodeSubset(c_SHORTCUT_SET.complement())
-
+S_SHORTCUT_SET = UnicodeSubset(' \n\t\r')
+D_SHORTCUT_SET = UnicodeSubset()
+D_SHORTCUT_SET._code_points = UNICODE_CATEGORIES['Nd'].code_points
+I_SHORTCUT_SET = UnicodeSubset(I_SHORTCUT_REPLACE)
+C_SHORTCUT_SET = UnicodeSubset(C_SHORTCUT_REPLACE)
 W_SHORTCUT_SET = UnicodeSubset()
 W_SHORTCUT_SET._code_points = sorted(
     UNICODE_CATEGORIES['P'].code_points + UNICODE_CATEGORIES['Z'].code_points +
     UNICODE_CATEGORIES['C'].code_points, key=lambda x: x if isinstance(x, int) else x[0]
 )
-w_SHORTCUT_SET = UnicodeSubset(W_SHORTCUT_SET.complement())
+W_SHORTCUT_SET = UnicodeSubset(W_SHORTCUT_SET.complement())
 
 # Single and Multi character escapes
 CHARACTER_ESCAPES = {
@@ -87,15 +79,15 @@ CHARACTER_ESCAPES = {
     '\\\\': '\\',
 
     # Multi-character escapes
-    '\\s': s_SHORTCUT_SET,
+    '\\s': S_SHORTCUT_SET,
     '\\S': S_SHORTCUT_SET,
-    '\\d': d_SHORTCUT_SET,
+    '\\d': D_SHORTCUT_SET,
     '\\D': D_SHORTCUT_SET,
-    '\\i': i_SHORTCUT_SET,
+    '\\i': I_SHORTCUT_SET,
     '\\I': I_SHORTCUT_SET,
-    '\\c': c_SHORTCUT_SET,
+    '\\c': C_SHORTCUT_SET,
     '\\C': C_SHORTCUT_SET,
-    '\\w': w_SHORTCUT_SET,
+    '\\w': W_SHORTCUT_SET,
     '\\W': W_SHORTCUT_SET,
 }
 

--- a/xmlschema/tests/test_regex.py
+++ b/xmlschema/tests/test_regex.py
@@ -336,6 +336,29 @@ class TestPatterns(unittest.TestCase):
         pattern = re.compile(regex)
         self.assertEqual(pattern.search('x11').group(0), 'x11')
         self.assertIsNone(pattern.search('3a'))
+        
+        regex = get_python_regex(r"\w*")
+        pattern = re.compile(regex)
+        self.assertEqual(pattern.search('aA_x7').group(0), 'aA_x7')
+        self.assertIsNone(pattern.search('.'))
+        self.assertIsNone(pattern.search('-'))
+        
+        regex = get_python_regex(r"\W*")
+        pattern = re.compile(regex)
+        self.assertIsNone(pattern.search('aA_x7'))
+        self.assertEqual(pattern.search('.-').group(0), '.-')
+        
+        regex = get_python_regex(r"\d*")
+        pattern = re.compile(regex)
+        self.assertEqual(pattern.search('6410').group(0), '6410')
+        self.assertIsNone(pattern.search('a'))
+        self.assertIsNone(pattern.search('-'))
+        
+        regex = get_python_regex(r"\D*")
+        pattern = re.compile(regex)
+        self.assertIsNone(pattern.search('6410'))
+        self.assertEqual(pattern.search('a').group(0), 'a')
+        self.assertEqual(pattern.search('-').group(0), '-')
 
     def test_empty_character_group_repr(self):
         regex = get_python_regex('[a-[a-f]]')


### PR DESCRIPTION
Upper-case and lower-case expressions (i.e. \w and \W) should match to different sequences. Tried to implement the behaviour according to https://www.w3.org/TR/xmlschema11-2/ G.4.2.5 (please check if implementation is correct!). For XSD 1.0, see https://www.w3.org/TR/xmlschema-2/.